### PR TITLE
Fixed first click flag bug

### DIFF
--- a/src/classes.py
+++ b/src/classes.py
@@ -229,17 +229,22 @@ class GameManager:
         Order to check:
             Flagged? -> Has mine? -> 0 or Not-0 adjacent mines?
         """
-        if(self.is_first_click == True):
-            self.change_state(GameStatus.PLAYING)
-            self.handle_first_click(i, j)
+
+        # Retrieve the cell that was clicked from the grid.
         clicked_cell = (self.grid[i][j])
-        # Uses a "is_hidden" function which is not yet implemented in the cell class.
+
+        # Determine whether the cell clicked on is still hidden and if it is flagged or not.
         hidden_cell = clicked_cell.is_hidden()
         is_flagged = clicked_cell.has_flag()
 
         # If the cell has a flag on it, ignore.
         if is_flagged == True:
             return
+        if(self.is_first_click == True):
+            self.change_state(GameStatus.PLAYING)
+            self.handle_first_click(i, j)
+        
+        
         
         # If the cell is already revealed, ignore.
         if hidden_cell == False:


### PR DESCRIPTION
Modified the order within handle_clicked_cell so the first check is whether or not the cell clicked is flagged. If so, the action will always be avoided/skipped. Before the handle_first_click was being called before the check, so if a flagged cell happened to be the first left click, it would generate the mines early.